### PR TITLE
Fix handler removal bug and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A Python library for managing exit handlers with enhanced features like decorato
 
 ## Installation
 
+This project requires **Python 3.12** or later.
+
 ```bash
 pip install easy-exit-calls
 ```
@@ -117,6 +119,14 @@ Decorator for registering a function as an exit handler.
 - `**handler_kwargs`:
     Optional keyword arguments to pass to the handler function.<br><br>
 
+
+## Running Tests
+
+Run the test suite with `pytest` from the project root:
+
+```bash
+pytest
+```
 
 ## Contributing
 

--- a/easy_exit_calls/classes.py
+++ b/easy_exit_calls/classes.py
@@ -413,12 +413,17 @@ class ExitCallHandler(Loggable):
 
         log.debug(f"Unregistering all exit handlers with name {name}")
 
-        for entry in self._handlers:
-            if 'handler_info' in entry:
-                info = entry['handler_info']
-                if info.get('name') == name:
-                    log.debug(f"Removing handler {info.get('module', '')}.{info.get('name')}")
-                    self._handlers.remove(entry)
+        to_remove = []
+        for entry in list(self._handlers):
+            info = entry.get('handler_info', {})
+            if info.get('name') == name:
+                log.debug(
+                    f"Removing handler {info.get('module', '')}.{info.get('name')}"
+                )
+                to_remove.append(entry)
+
+        for entry in to_remove:
+            self._handlers.remove(entry)
 
         log.debug(f"All handlers with name {name} unregistered successfully")
 

--- a/easy_exit_calls/common/__init__.py
+++ b/easy_exit_calls/common/__init__.py
@@ -1,8 +1,5 @@
-"""
-Author: Taylor B. tayjaybabee@gmail.com
-Date: 2025-02-26 18:54:51
-LastEditors: Taylor B. tayjaybabee@gmail.com
-LastEditTime: 2025-02-26 19:14:22
-FilePath: easy_exit_calls/common/__init__.py
-Description: 这是默认设置,可以在设置》工具》File Description中进行配置
-"""
+"""Common utilities and metadata for :mod:`easy_exit_calls`."""
+
+from . import meta
+
+__all__ = ["meta"]

--- a/easy_exit_calls/common/meta/__init__.py
+++ b/easy_exit_calls/common/meta/__init__.py
@@ -1,5 +1,5 @@
 from easy_exit_calls.common.meta.author import AUTHOR, SOFTWARE_ORG_URLS
-
+from easy_exit_calls.common.meta.package import PACKAGE_NAME, VERSION
 
 __all__ = [
     'AUTHOR',

--- a/easy_exit_calls/common/meta/author/contributors/__init__.py
+++ b/easy_exit_calls/common/meta/author/contributors/__init__.py
@@ -1,8 +1,2 @@
-"""
-Author: Taylor B. tayjaybabee@gmail.com
-Date: 2025-02-26 19:00:17
-LastEditors: Taylor B. tayjaybabee@gmail.com
-LastEditTime: 2025-02-26 19:14:22
-FilePath: easy_exit_calls/common/meta/author/contributors/__init__.py
-Description: 这是默认设置,可以在设置》工具》File Description中进行配置
-"""
+"""Information about project contributors."""
+

--- a/easy_exit_calls/common/meta/author/main/__init__.py
+++ b/easy_exit_calls/common/meta/author/main/__init__.py
@@ -1,8 +1,2 @@
-"""
-Author: Taylor B. tayjaybabee@gmail.com
-Date: 2025-02-26 18:59:28
-LastEditors: Taylor B. tayjaybabee@gmail.com
-LastEditTime: 2025-02-26 19:14:21
-FilePath: easy_exit_calls/common/meta/author/main/__init__.py
-Description: 这是默认设置,可以在设置》工具》File Description中进行配置
-"""
+"""Primary author information for :mod:`easy_exit_calls`."""
+

--- a/easy_exit_calls/common/meta/package/__init__.py
+++ b/easy_exit_calls/common/meta/package/__init__.py
@@ -1,8 +1,7 @@
-"""
-Author: Taylor B. tayjaybabee@gmail.com
-Date: 2025-02-27 02:15:10
-LastEditors: Taylor B. tayjaybabee@gmail.com
-LastEditTime: 2025-02-27 02:15:54
-FilePath: easy_exit_calls/common/meta/package/__init__.py
-Description: 这是默认设置,可以在设置》工具》File Description中进行配置
-"""
+"""Package metadata for :mod:`easy_exit_calls`."""
+
+from .version import VERSION
+
+PACKAGE_NAME = "easy_exit_calls"
+
+__all__ = ["PACKAGE_NAME", "VERSION"]

--- a/easy_exit_calls/helpers/__init__.py
+++ b/easy_exit_calls/helpers/__init__.py
@@ -1,8 +1,6 @@
-"""
-Author: Taylor B. tayjaybabee@gmail.com
-Date: 2025-02-28 18:16:47
-LastEditors: Taylor B. tayjaybabee@gmail.com
-LastEditTime: 2025-02-28 18:21:01
-FilePath: easy_exit_calls/helpers/__init__.py
-Description: 这是默认设置,可以在设置》工具》File Description中进行配置
-"""
+"""Helper utilities used by :mod:`easy_exit_calls`."""
+
+from .decorator import register_exit_handler
+from .handler_list import HandlerList
+
+__all__ = ["register_exit_handler", "HandlerList"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,3 +30,17 @@ pip install easy-exit-calls
     ```bash
     poetry install
     ```
+
+### Running the Examples
+
+After installation, run an example script from the project root:
+
+```bash
+python examples/manual_registration.py
+```
+
+You can also enable logging output:
+
+```bash
+python examples/manual_registration_with_logging.py --log-level DEBUG
+```

--- a/tests/test_exit_call_handler.py
+++ b/tests/test_exit_call_handler.py
@@ -1,0 +1,60 @@
+from easy_exit_calls import ExitCallHandler
+
+
+def setup_function(_):
+    """Clear handlers before each test."""
+    ExitCallHandler().clear_handlers()
+
+
+def teardown_function(_):
+    """Clear handlers after each test."""
+    ExitCallHandler().clear_handlers()
+
+
+def test_lifo_execution_order():
+    calls = []
+
+    def first():
+        calls.append("first")
+
+    def second():
+        calls.append("second")
+
+    ech = ExitCallHandler()
+    ech.register_handler(first)
+    ech.register_handler(second)
+
+    ech.call_handlers()
+
+    assert calls == ["second", "first"]
+
+
+def test_unregister_by_uuid():
+    def handler():
+        pass
+
+    ech = ExitCallHandler()
+    uid = ech.register_handler(handler)
+
+    assert ech.find_handler_by_uuid(uid) is not None
+    assert ech.unregister_by_uuid(uid) is True
+    assert ech.find_handler_by_uuid(uid) is None
+
+
+def test_unregister_all_with_name():
+    def target(a=None):
+        pass
+
+    def other():
+        pass
+
+    ech = ExitCallHandler()
+    ech.register_handler(target, 1)
+    ech.register_handler(target, 2)
+    ech.register_handler(other)
+
+    ech.unregister_all_with_name("target")
+
+    names = [h["handler_info"]["name"] for h in ech.handlers]
+    assert names == ["other"]
+


### PR DESCRIPTION
## Summary
- clean up placeholder docstrings and export public names
- fix list mutation in `unregister_all_with_name`
- document Python requirement and how to run tests
- finish example README usage section
- add basic unit tests for `ExitCallHandler`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'inspy_logger')*

------
https://chatgpt.com/codex/tasks/task_e_684a1a70bd2c832d936f07d7479d7105

## Summary by Sourcery

Fix handler removal logic, clean up module docstrings and exports, enrich documentation, and add basic unit tests for ExitCallHandler

Bug Fixes:
- Prevent in-place list mutation in unregister_all_with_name to ensure all matching handlers are removed

Enhancements:
- Clean up placeholder file headers across modules and explicitly export public APIs via __all__

Documentation:
- Specify Python 3.12 requirement and add instructions for running tests in the main README
- Expand example README with usage commands and logging options

Tests:
- Add basic unit tests for ExitCallHandler covering registration, LIFO execution order, and unregistration by name and UUID